### PR TITLE
Add services overview and four service detail pages

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,26 @@
+---
+interface Props {
+  items: Array<{ label: string; href?: string }>;
+}
+
+const { items } = Astro.props;
+---
+
+<nav aria-label="Breadcrumb" class="mb-6">
+  <ol class="flex flex-wrap items-center gap-1 text-body-sm">
+    {items.map((item, i) => (
+      <>
+        {i > 0 && <li class="text-neutral-400" aria-hidden="true">/</li>}
+        <li>
+          {item.href ? (
+            <a href={item.href} class="text-neutral-300 hover:text-white transition-colors">
+              {item.label}
+            </a>
+          ) : (
+            <span class="text-white font-medium">{item.label}</span>
+          )}
+        </li>
+      </>
+    ))}
+  </ol>
+</nav>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,9 +1,9 @@
 ---
 const services = [
-  { label: 'Store Builds', href: '/services/' },
-  { label: 'Optimization', href: '/services/' },
-  { label: 'Migration', href: '/services/' },
-  { label: 'Management', href: '/services/' },
+  { label: 'Store Builds', href: '/services/store-builds/' },
+  { label: 'Optimization', href: '/services/optimization/' },
+  { label: 'Migration', href: '/services/migration/' },
+  { label: 'Management', href: '/services/management/' },
 ];
 
 const company = [

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -1,0 +1,111 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Service",
+      "name": "Shopify Services",
+      "description": "Shopify store builds, optimization, migration, and monthly management for growing e-commerce brands.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Services", "item": "https://ladingandlaunch.com/services/" }
+      ]
+    }
+  ]
+};
+
+const services = [
+  {
+    title: 'Shopify Store Builds',
+    description: 'Custom Shopify stores designed to convert — from theme customization to full custom builds. SEO and conversion optimization baked into every project.',
+    price: 'Starting at $2,000',
+    deliverables: ['Custom theme build', 'Mobile-responsive design', 'On-page SEO setup', 'Conversion-optimized product pages'],
+    href: '/services/store-builds/',
+  },
+  {
+    title: 'Store Optimization',
+    description: 'Speed, SEO, and conversion improvements for Shopify stores that need to perform better. Find out what\'s holding your store back and fix it.',
+    price: 'Starting at $500',
+    deliverables: ['Full store audit', 'Speed optimization', 'Conversion rate improvements', 'SEO fixes and enhancements'],
+    href: '/services/optimization/',
+  },
+  {
+    title: 'Platform Migration',
+    description: 'Move from WooCommerce, Wix, Squarespace, or BigCommerce to Shopify with zero data loss and minimal downtime.',
+    price: 'Starting at $1,500',
+    deliverables: ['Full product and customer migration', 'SEO redirect mapping', 'Theme build on Shopify', 'Post-migration QA testing'],
+    href: '/services/migration/',
+  },
+  {
+    title: 'Monthly Management',
+    description: 'Ongoing Shopify store management so you can focus on growing your brand. Updates, monitoring, optimization, and dev support every month.',
+    price: 'Starting at $300/mo',
+    deliverables: ['Shopify updates and monitoring', 'Monthly dev hours', 'Performance tracking', 'Priority support'],
+    href: '/services/management/',
+  },
+];
+---
+
+<BaseLayout
+  title="Shopify Services — Store Builds, Optimization & Management | Lading & Launch"
+  description="From new Shopify store builds to platform migrations and ongoing management. Transparent pricing. Expert Shopify development for growing e-commerce brands."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <div class="text-center animate-fade-in">
+      <p class="text-label text-accent mb-4">Our Services</p>
+      <h1 class="text-display text-white section__heading">Shopify Services for Growing Brands</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl mx-auto">From new store builds to ongoing management — everything your Shopify store needs to grow. Transparent pricing on every service.</p>
+    </div>
+  </Section>
+
+  <!-- Service Cards -->
+  <Section background="cream">
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {services.map((service) => (
+        <Card href={service.href}>
+          <h2 class="text-h2 section__heading">{service.title}</h2>
+          <p class="text-body section__description">{service.description}</p>
+          <p class="text-h3 text-accent section__heading">{service.price}</p>
+          <ul class="text-body-sm text-neutral-600 space-y-1 mb-4">
+            {service.deliverables.map((item) => (
+              <li>&#10003; {item}</li>
+            ))}
+          </ul>
+          <span class="text-body-sm text-primary-light font-semibold">Learn more &rarr;</span>
+        </Card>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- Why Transparent Pricing -->
+  <Section background="white">
+    <div class="text-center animate-fade-in">
+      <h2 class="text-h2 section__heading">Why We Publish Our Prices</h2>
+      <p class="text-body-lg text-neutral-700 max-w-2xl mx-auto">Most agencies make you sit through a sales call before you see a number. We think that's backwards. You should know what a project costs before you pick up the phone. Our prices are starting points — every project is scoped based on your specific needs, but you'll never be surprised by the ballpark.</p>
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Not Sure What You Need?"
+    description="Book a free discovery call. We'll look at your store, talk through your goals, and recommend the right service — even if it's not one of ours."
+    buttonText="Book a Discovery Call"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/pages/services/management.astro
+++ b/src/pages/services/management.astro
@@ -1,0 +1,191 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const faqs = [
+  {
+    question: 'Can I cancel anytime?',
+    answer: 'Yes. Our management plans are month-to-month with no long-term contracts. Cancel anytime with 30 days notice.',
+  },
+  {
+    question: 'What counts toward my dev hours?',
+    answer: 'Any development work on your store — new features, design changes, bug fixes, app installations, and custom code. We track hours and report them monthly.',
+  },
+  {
+    question: 'What if I need more hours than my plan includes?',
+    answer: 'Additional hours are billed at $100/hour. Or you can upgrade to a higher plan if you consistently need more time.',
+  },
+  {
+    question: 'Do I need a management plan if you built my store?',
+    answer: 'You don\'t need one, but we recommend it. Shopify stores need ongoing updates, security monitoring, and optimization. Most clients who skip management come back within 3 months.',
+  },
+];
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Service",
+      "name": "Monthly Shopify Management",
+      "description": "Ongoing Shopify store management, updates, monitoring, and optimization with monthly dev hours included.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": "300",
+        "priceSpecification": { "@type": "PriceSpecification", "minPrice": "300", "priceCurrency": "USD" }
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Services", "item": "https://ladingandlaunch.com/services/" },
+        { "@type": "ListItem", "position": 3, "name": "Management", "item": "https://ladingandlaunch.com/services/management/" }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": faqs.map(faq => ({
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+      }))
+    }
+  ]
+};
+
+const tiers = [
+  {
+    name: 'Essential',
+    price: '$300/mo',
+    bestFor: 'Stores that need basic maintenance and peace of mind',
+    includes: [
+      'Shopify updates and security monitoring',
+      'Uptime monitoring',
+      'Basic theme tweaks',
+      '2 hours/month dev time',
+      'Email support',
+    ],
+    recommended: false,
+  },
+  {
+    name: 'Growth',
+    price: '$500/mo',
+    bestFor: 'Stores that need active optimization and reporting',
+    includes: [
+      'Everything in Essential',
+      'Performance monitoring',
+      'Monthly analytics report',
+      '5 hours/month dev time',
+      'Priority support',
+    ],
+    recommended: true,
+  },
+  {
+    name: 'Scale',
+    price: '$1,000/mo',
+    bestFor: 'Stores that need a strategic partner, not just maintenance',
+    includes: [
+      'Everything in Growth',
+      'Conversion optimization',
+      'A/B testing',
+      '10 hours/month dev time',
+      'Bi-weekly strategy calls',
+    ],
+    recommended: false,
+  },
+];
+
+const covered = [
+  { title: 'Shopify Updates', description: 'We apply Shopify platform updates, theme updates, and app updates so nothing breaks unexpectedly.' },
+  { title: 'Security Monitoring', description: 'We monitor your store for security issues, SSL problems, and suspicious activity.' },
+  { title: 'Performance Tracking', description: 'Monthly reports on speed, uptime, and key metrics so you always know how your store is performing.' },
+  { title: 'Bug Fixes & Tweaks', description: 'Small changes, fixes, and improvements — handled within your monthly dev hours.' },
+  { title: 'Conversion Optimization', description: 'On Growth and Scale plans, we actively test and improve your store\'s conversion rate.' },
+  { title: 'Strategic Guidance', description: 'On the Scale plan, we\'re not just fixing things — we\'re helping you plan what to build next.' },
+];
+---
+
+<BaseLayout
+  title="Shopify Monthly Management & Support — From $300/mo | Lading & Launch"
+  description="Ongoing Shopify store management, updates, monitoring, and optimization. Monthly dev hours included. Plans from $300/mo."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Services', href: '/services/' },
+      { label: 'Management' },
+    ]} />
+    <div class="animate-fade-in">
+      <h1 class="text-display text-white section__heading">Monthly Shopify Management</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl section__description">Your store doesn't stop needing attention after launch. We keep it updated, fast, and optimized every month — so you can focus on selling.</p>
+    </div>
+  </Section>
+
+  <!-- Pricing Tiers -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Management Plans</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {tiers.map((tier) => (
+        <Card class:list={[tier.recommended && 'border-t-4 border-accent relative']}>
+          {tier.recommended && (
+            <span class="text-label bg-accent text-primary-dark rounded-full px-3 py-1 inline-block mb-3">Recommended</span>
+          )}
+          <h3 class="text-h3 section__heading">{tier.name}</h3>
+          <p class="text-h2 text-accent section__heading">{tier.price}</p>
+          <p class="text-body-sm text-neutral-500 italic mb-4">Best for: {tier.bestFor}</p>
+          <ul class="text-body space-y-2">
+            {tier.includes.map((item) => (
+              <li>&#10003; {item}</li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- What's Covered -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">What We Handle Every Month</h2>
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {covered.map((item) => (
+        <div>
+          <h3 class="text-h4 section__heading">{item.title}</h3>
+          <p class="text-body text-neutral-600">{item.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- FAQ -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Frequently Asked Questions</h2>
+    <div class="max-w-2xl mx-auto space-y-8 animate-fade-in">
+      {faqs.map((faq) => (
+        <div>
+          <h3 class="text-h3 section__heading">{faq.question}</h3>
+          <p class="text-body text-neutral-600">{faq.answer}</p>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Want Ongoing Support for Your Store?"
+    description="Book a call and we'll recommend the right plan based on your store's needs."
+    buttonText="Book a Discovery Call"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/pages/services/migration.astro
+++ b/src/pages/services/migration.astro
@@ -1,0 +1,164 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const faqs = [
+  {
+    question: 'Will I lose my Google rankings when I migrate?',
+    answer: 'Not if it\'s done right. We create 301 redirects for every URL on your current site, which tells Google your content has moved. Rankings typically stabilize within 2-4 weeks.',
+  },
+  {
+    question: 'How long does a migration take?',
+    answer: 'Simple migrations (under 500 products, no complex integrations) take 1-2 weeks. Complex migrations with custom integrations can take 3-6 weeks.',
+  },
+  {
+    question: 'Will my store be down during migration?',
+    answer: 'No. We build your new Shopify store while your old store stays live. We switch over once the new store is tested and ready — downtime is typically under an hour.',
+  },
+  {
+    question: 'Can I change my store design during migration?',
+    answer: 'Yes — in fact, we recommend it. Every migration includes a new theme build on Shopify, so it\'s the perfect time for a fresh design.',
+  },
+];
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Service",
+      "name": "Shopify Platform Migration",
+      "description": "Migrate your store to Shopify from WooCommerce, Wix, Squarespace, or BigCommerce with zero data loss.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": "1500",
+        "priceSpecification": { "@type": "PriceSpecification", "minPrice": "1500", "priceCurrency": "USD" }
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Services", "item": "https://ladingandlaunch.com/services/" },
+        { "@type": "ListItem", "position": 3, "name": "Migration", "item": "https://ladingandlaunch.com/services/migration/" }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": faqs.map(faq => ({
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+      }))
+    }
+  ]
+};
+
+const platforms = [
+  {
+    name: 'From WooCommerce',
+    price: '$2,000 – $5,000',
+    includes: ['Product, customer, and order migration', 'SEO redirect mapping', 'Theme rebuild on Shopify', 'Post-migration QA testing'],
+  },
+  {
+    name: 'From Wix / Squarespace',
+    price: '$1,500 – $4,000',
+    includes: ['Content and product migration', 'SEO redirect mapping', 'Theme build on Shopify', 'Post-migration QA testing'],
+  },
+  {
+    name: 'From BigCommerce / Magento',
+    price: '$3,000 – $8,000+',
+    includes: ['Complex data migration with custom mapping', 'Integration migration', 'Theme rebuild on Shopify', 'Extensive QA and testing'],
+  },
+];
+
+const migrates = [
+  { title: 'Products', description: 'All products, variants, images, descriptions, and inventory levels.' },
+  { title: 'Customers', description: 'Customer accounts, contact info, and order history.' },
+  { title: 'Orders', description: 'Historical order data so your records stay complete.' },
+  { title: 'SEO', description: '301 redirects from every old URL to the new Shopify URL. Your Google rankings are protected.' },
+  { title: 'Content', description: 'Blog posts, pages, and media files migrated to your new store.' },
+  { title: 'Integrations', description: 'We map your existing tools to Shopify equivalents and set up new integrations.' },
+];
+---
+
+<BaseLayout
+  title="Shopify Migration — WooCommerce, Wix, Squarespace & More | Lading & Launch"
+  description="Migrate your store to Shopify from WooCommerce, Wix, Squarespace, or BigCommerce. Zero data loss, SEO redirects, and a new theme. Starting at $1,500."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Services', href: '/services/' },
+      { label: 'Migration' },
+    ]} />
+    <div class="animate-fade-in">
+      <h1 class="text-display text-white section__heading">Migrate to Shopify</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl section__description">Moving platforms is stressful. We handle everything — products, customers, orders, SEO redirects, and a brand new Shopify store — so you don't lose a single sale.</p>
+    </div>
+  </Section>
+
+  <!-- Migration Pricing -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Migration Pricing</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {platforms.map((platform) => (
+        <Card>
+          <h3 class="text-h3 section__heading">{platform.name}</h3>
+          <p class="text-h2 text-accent section__heading">{platform.price}</p>
+          <ul class="text-body space-y-2">
+            {platform.includes.map((item) => (
+              <li>&#10003; {item}</li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </Grid>
+    <p class="text-body-sm text-neutral-500 text-center mt-6">Pricing depends on the number of products, complexity of integrations, and customization needed. We'll scope your specific migration during the discovery call.</p>
+  </Section>
+
+  <!-- What We Migrate -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Everything Moves With You</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {migrates.map((item) => (
+        <div>
+          <h3 class="text-h3 section__heading">{item.title}</h3>
+          <p class="text-body text-neutral-600">{item.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- FAQ -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Frequently Asked Questions</h2>
+    <div class="max-w-2xl mx-auto space-y-8 animate-fade-in">
+      {faqs.map((faq) => (
+        <div>
+          <h3 class="text-h3 section__heading">{faq.question}</h3>
+          <p class="text-body text-neutral-600">{faq.answer}</p>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Ready to Move to Shopify?"
+    description="Book a discovery call and we'll scope your migration — platform, timeline, and pricing."
+    buttonText="Book a Discovery Call"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/pages/services/optimization.astro
+++ b/src/pages/services/optimization.astro
@@ -1,0 +1,165 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const faqs = [
+  {
+    question: 'How do I know if my store needs optimization?',
+    answer: 'If your Shopify store loads in more than 3 seconds, your conversion rate is below 1.5%, or your Google rankings are slipping — optimization will help. Start with a Store Audit to get a clear picture.',
+  },
+  {
+    question: 'Will optimization break anything on my store?',
+    answer: 'No. We test everything in a staging environment before touching your live store. And we document every change so nothing is a mystery.',
+  },
+  {
+    question: 'How long does optimization take?',
+    answer: 'A Store Audit takes 3-5 business days. Speed optimization is typically 1-2 weeks. Conversion optimization is 2-4 weeks depending on scope.',
+  },
+  {
+    question: 'Do I need to pause my ads during optimization?',
+    answer: 'No. We make changes carefully and incrementally. Your store stays live and functional throughout the process.',
+  },
+];
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Service",
+      "name": "Shopify Store Optimization",
+      "description": "Shopify store audits, speed optimization, and conversion rate improvements.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": "500",
+        "priceSpecification": { "@type": "PriceSpecification", "minPrice": "500", "priceCurrency": "USD" }
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Services", "item": "https://ladingandlaunch.com/services/" },
+        { "@type": "ListItem", "position": 3, "name": "Optimization", "item": "https://ladingandlaunch.com/services/optimization/" }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": faqs.map(faq => ({
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+      }))
+    }
+  ]
+};
+
+const services = [
+  {
+    name: 'Store Audit',
+    price: '$500 – $1,000',
+    description: 'A full technical review of your store — speed, SEO, UX, conversion, mobile, and accessibility. You get an actionable report with prioritized recommendations.',
+    deliverables: ['Speed analysis', 'SEO audit', 'UX review', 'Conversion assessment', 'Mobile testing', 'Prioritized action plan'],
+  },
+  {
+    name: 'Speed Optimization',
+    price: '$750 – $1,500',
+    description: 'Slow stores lose sales. We clean up your theme code, optimize images, audit your apps, and implement lazy loading and caching to get your store loading fast.',
+    deliverables: ['Theme code cleanup', 'Image optimization', 'App audit and cleanup', 'Lazy loading implementation', 'CDN and caching setup'],
+  },
+  {
+    name: 'Conversion Optimization',
+    price: '$1,500 – $3,000',
+    description: 'Your traffic is fine but your conversion rate isn\'t. We redesign product pages, optimize checkout flow, add trust signals, and set up A/B testing.',
+    deliverables: ['Product page redesign', 'Checkout optimization', 'Trust signal implementation', 'A/B test setup', 'Analytics configuration'],
+  },
+];
+
+const problems = [
+  { title: 'Slow Page Load Times', description: 'If your store takes more than 3 seconds to load, you\'re losing customers. We typically cut load times by 40-60%.' },
+  { title: 'Low Conversion Rates', description: 'Industry average for Shopify stores is 1.5-2%. If you\'re below that, there\'s room to improve through better UX and product page design.' },
+  { title: 'Poor Mobile Experience', description: 'Over 70% of your visitors are on mobile. If your store isn\'t optimized for mobile, most of your traffic is having a bad experience.' },
+  { title: 'Dropping SEO Rankings', description: 'Slow speeds, missing meta tags, broken links, and poor site structure all hurt your Google rankings. We fix the technical SEO issues holding you back.' },
+];
+---
+
+<BaseLayout
+  title="Shopify Store Optimization — Audits, Speed & Conversion | Lading & Launch"
+  description="Shopify store audits, speed optimization, and conversion rate improvements. Find out what's holding your store back and fix it. Starting at $500."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Services', href: '/services/' },
+      { label: 'Optimization' },
+    ]} />
+    <div class="animate-fade-in">
+      <h1 class="text-display text-white section__heading">Shopify Store Optimization</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl section__description">Your store is live but it's not performing the way it should. We find what's broken — speed, SEO, conversion — and fix it.</p>
+    </div>
+  </Section>
+
+  <!-- Services & Pricing -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Optimization Services</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {services.map((service) => (
+        <Card>
+          <h3 class="text-h3 section__heading">{service.name}</h3>
+          <p class="text-h2 text-accent section__heading">{service.price}</p>
+          <p class="text-body section__description">{service.description}</p>
+          <ul class="text-body-sm text-neutral-600 space-y-1">
+            {service.deliverables.map((item) => (
+              <li>&#10003; {item}</li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- Common Problems -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Signs Your Store Needs Optimization</h2>
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {problems.map((item) => (
+        <div>
+          <h3 class="text-h3 section__heading">{item.title}</h3>
+          <p class="text-body text-neutral-600">{item.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- FAQ -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Frequently Asked Questions</h2>
+    <div class="max-w-2xl mx-auto space-y-8 animate-fade-in">
+      {faqs.map((faq) => (
+        <div>
+          <h3 class="text-h3 section__heading">{faq.question}</h3>
+          <p class="text-body text-neutral-600">{faq.answer}</p>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Want to Know What's Holding Your Store Back?"
+    description="Start with a Store Audit. We'll tell you exactly what to fix and how much it'll cost."
+    buttonText="Book a Discovery Call"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/pages/services/store-builds.astro
+++ b/src/pages/services/store-builds.astro
@@ -1,0 +1,221 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const faqs = [
+  {
+    question: 'How long does a Shopify store build take?',
+    answer: 'Starter stores typically take 1-2 weeks. Growth stores take 2-4 weeks. Premium builds with complex requirements can take 4-8 weeks. We\'ll give you a specific timeline during the discovery phase.',
+  },
+  {
+    question: 'Do I need to provide the design?',
+    answer: 'No. We handle design and development. If you have brand guidelines, a logo, or inspiration sites, that helps — but we can work with whatever you have.',
+  },
+  {
+    question: 'What if I already have a Shopify store that needs a redesign?',
+    answer: 'That\'s common. We treat redesigns the same as new builds — we\'ll assess what you have, keep what works, and rebuild what doesn\'t. Pricing is the same.',
+  },
+  {
+    question: 'Do you write product descriptions?',
+    answer: 'We can set up your products with the descriptions you provide. If you need copywriting, we can recommend partners or handle it as an add-on.',
+  },
+  {
+    question: 'What happens after launch?',
+    answer: 'We offer monthly management plans starting at $300/mo for ongoing support, updates, and optimization. Or we hand over the store and you manage it yourself — your choice.',
+  },
+];
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Service",
+      "name": "Custom Shopify Store Builds",
+      "description": "Custom Shopify store design and development with SEO and conversion optimization built in.",
+      "provider": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": "2000",
+        "priceSpecification": { "@type": "PriceSpecification", "minPrice": "2000", "priceCurrency": "USD" }
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Services", "item": "https://ladingandlaunch.com/services/" },
+        { "@type": "ListItem", "position": 3, "name": "Store Builds", "item": "https://ladingandlaunch.com/services/store-builds/" }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": faqs.map(faq => ({
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+      }))
+    }
+  ]
+};
+
+const tiers = [
+  {
+    name: 'Starter Store',
+    price: '$2,000 – $3,500',
+    bestFor: 'New brands launching their first Shopify store',
+    includes: [
+      'Theme customization',
+      '5–15 products set up',
+      'Essential pages (Home, About, Contact, FAQ, Policies)',
+      'Mobile-responsive design',
+      'Basic on-page SEO',
+      '1-2 week delivery',
+    ],
+    recommended: false,
+  },
+  {
+    name: 'Growth Store',
+    price: '$4,000 – $7,000',
+    bestFor: 'Growing brands that need advanced functionality',
+    includes: [
+      'Custom theme build or heavy customization',
+      '15–50 products set up',
+      'Advanced features (bundles, subscriptions, upsells)',
+      'Full SEO implementation',
+      'Third-party app integrations',
+      '2-4 week delivery',
+    ],
+    recommended: true,
+  },
+  {
+    name: 'Premium Store',
+    price: '$8,000 – $15,000+',
+    bestFor: 'Established brands with complex requirements',
+    includes: [
+      'Full custom build from scratch',
+      'Complex functionality and custom features',
+      'ERP, 3PL, and custom app integrations',
+      'Shopify Plus setup and configuration',
+      'Full SEO and performance optimization',
+      '4-8 week delivery',
+    ],
+    recommended: false,
+  },
+];
+
+const includes = [
+  { title: 'Conversion-Focused Design', description: 'Every page is designed to guide visitors toward a purchase. Clear CTAs, trust signals, and optimized product layouts.' },
+  { title: 'Mobile-First Development', description: 'Over 70% of e-commerce traffic is mobile. Your store will look and perform flawlessly on every device.' },
+  { title: 'On-Page SEO', description: 'Proper meta tags, semantic HTML, image optimization, schema markup, and site speed — so Google can find and rank your store.' },
+  { title: 'Speed Optimization', description: 'Fast stores convert better. We optimize images, minimize code, and ensure your store loads in under 3 seconds.' },
+  { title: 'Product Page Setup', description: 'We set up your products with optimized titles, descriptions, images, and variant configurations.' },
+  { title: 'Launch Support', description: 'We don\'t just hand over the keys. We walk you through your store, train you on Shopify, and make sure the launch goes smoothly.' },
+];
+
+const process = [
+  { step: '01', title: 'Discovery & Planning', description: 'We start with a call to understand your brand, products, and goals. You get a detailed project scope and timeline before any work begins.' },
+  { step: '02', title: 'Design & Build', description: 'We build your store with regular check-ins so you can review progress. No black box — you see what we\'re building as we build it.' },
+  { step: '03', title: 'Review & Refine', description: 'You review the full store and we make revisions until you\'re happy. We won\'t launch until everything is right.' },
+  { step: '04', title: 'Launch & Handoff', description: 'We launch your store, verify everything works, and walk you through managing it day-to-day. If you want ongoing support, we offer monthly management plans.' },
+];
+---
+
+<BaseLayout
+  title="Custom Shopify Store Builds — From $2,000 | Lading & Launch"
+  description="Custom Shopify store design and development with SEO and conversion optimization built in. Theme customization to full custom builds. Transparent pricing."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Services', href: '/services/' },
+      { label: 'Store Builds' },
+    ]} />
+    <div class="animate-fade-in">
+      <h1 class="text-display text-white section__heading">Custom Shopify Store Builds</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl section__description">Your store is your most important sales tool. We build Shopify stores that look great, load fast, and actually convert visitors into customers.</p>
+    </div>
+  </Section>
+
+  <!-- Pricing Tiers -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Choose Your Package</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {tiers.map((tier) => (
+        <Card class:list={[tier.recommended && 'border-t-4 border-accent relative']}>
+          {tier.recommended && (
+            <span class="text-label bg-accent text-primary-dark rounded-full px-3 py-1 inline-block mb-3">Recommended</span>
+          )}
+          <h3 class="text-h3 section__heading">{tier.name}</h3>
+          <p class="text-h2 text-accent section__heading">{tier.price}</p>
+          <p class="text-body-sm text-neutral-500 italic mb-4">Best for: {tier.bestFor}</p>
+          <ul class="text-body space-y-2">
+            {tier.includes.map((item) => (
+              <li>&#10003; {item}</li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- What's Included -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Every Store Build Includes</h2>
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {includes.map((item) => (
+        <div>
+          <h3 class="text-h4 section__heading">{item.title}</h3>
+          <p class="text-body text-neutral-600">{item.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- Process -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">How We Build Your Store</h2>
+    <div class="max-w-2xl mx-auto space-y-10 animate-fade-in">
+      {process.map((item) => (
+        <div class="flex gap-6">
+          <span class="text-4xl font-bold text-accent shrink-0">{item.step}</span>
+          <div>
+            <h3 class="text-h3 section__heading">{item.title}</h3>
+            <p class="text-body text-neutral-600">{item.description}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <!-- FAQ -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Frequently Asked Questions</h2>
+    <div class="max-w-2xl mx-auto space-y-8 animate-fade-in">
+      {faqs.map((faq) => (
+        <div>
+          <h3 class="text-h3 section__heading">{faq.question}</h3>
+          <p class="text-body text-neutral-600">{faq.answer}</p>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Ready to Build Your Store?"
+    description="Book a free discovery call and let's plan your Shopify store."
+    buttonText="Book a Discovery Call"
+    buttonHref="/contact/"
+  />
+</BaseLayout>


### PR DESCRIPTION
New pages:
- /services/ — overview with 4 linked service cards and pricing ranges
- /services/store-builds/ — 3 pricing tiers, included features, process, FAQ
- /services/optimization/ — 3 service types with pricing, common problems, FAQ
- /services/migration/ — pricing by platform, migration checklist, FAQ
- /services/management/ — 3 monthly plans, coverage details, FAQ

Each detail page includes breadcrumbs, JSON-LD schemas (Service, BreadcrumbList, FAQPage), and recommended tier visual treatment on Store Builds and Management pages.

Also adds Breadcrumb.astro component and updates footer service links to point to individual service pages.