### PR TITLE
Add apps overview and detail pages for DealSnap and Scratch & Win

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,8 +13,8 @@ const company = [
 ];
 
 const apps = [
-  { label: 'DealSnap', href: '/apps/' },
-  { label: 'Scratch & Win', href: '/apps/' },
+  { label: 'DealSnap', href: '/apps/dealsnap/' },
+  { label: 'Scratch & Win', href: '/apps/scratch-and-win/' },
 ];
 ---
 

--- a/src/pages/apps/dealsnap.astro
+++ b/src/pages/apps/dealsnap.astro
@@ -1,0 +1,152 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Button from '../../components/Button.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import Grid from '../../components/Grid.astro';
+import Accordion from '../../components/Accordion.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const faqs = [
+  {
+    question: 'When will DealSnap be available?',
+    answer: "DealSnap is currently in development and will be available on the Shopify App Store soon. Join the waitlist to be notified when it launches.",
+  },
+  {
+    question: 'How much will it cost?',
+    answer: "Pricing will be announced at launch. We're planning affordable tiers starting under $30/month, with a free trial to start.",
+  },
+  {
+    question: 'Will it work with my existing Shopify theme?',
+    answer: "Yes. DealSnap works with any Shopify theme — no custom code or theme modifications required.",
+  },
+  {
+    question: "Does it conflict with Shopify's built-in discounts?",
+    answer: "No. DealSnap is designed to work alongside Shopify's native discount system, not replace it.",
+  },
+];
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "name": "DealSnap",
+      "description": "Create mix-and-match bundles, quantity breaks, and automatic discount combinations on Shopify.",
+      "applicationCategory": "BusinessApplication",
+      "operatingSystem": "Shopify",
+      "author": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://ladingandlaunch.com/apps/" },
+        { "@type": "ListItem", "position": 3, "name": "DealSnap", "item": "https://ladingandlaunch.com/apps/dealsnap/" }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": faqs.map(faq => ({
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+      }))
+    }
+  ]
+};
+
+const features = [
+  { title: 'Mix & Match Bundles', description: 'Let customers build their own bundles across products or collections. Buy any 3 items from a collection and get 15% off — DealSnap handles the math.' },
+  { title: 'Quantity Breaks', description: 'Reward bulk purchases. Buy 2 get 10% off, buy 5 get 20% off. Automatic tiered pricing that encourages larger orders.' },
+  { title: 'Automatic Discount Combinations', description: "Stack multiple discount rules without conflicts. Shopify limits you to one automatic discount — DealSnap doesn't." },
+  { title: 'Simple Setup', description: "No code required. Set up discount rules through a clean admin interface in minutes, not hours. Works with your existing Shopify theme." },
+];
+
+const audiences = [
+  { title: 'DTC Brands', description: 'Brands selling direct-to-consumer that want to increase average order value through smart bundling.' },
+  { title: 'Subscription Stores', description: 'Stores with subscription products that need flexible bundle-and-save pricing.' },
+  { title: 'High-SKU Stores', description: 'Stores with large catalogs that want to run mix-and-match promotions across collections.' },
+];
+---
+
+<BaseLayout
+  title="DealSnap — Flexible Shopify Discounts & Bundles | Lading & Launch"
+  description="Create mix-and-match bundles, quantity breaks, and automatic discount combinations on Shopify. No workarounds. DealSnap by Lading & Launch — coming soon."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Apps', href: '/apps/' },
+      { label: 'DealSnap' },
+    ]} />
+    <div class="text-center animate-fade-in">
+      <p class="text-label text-accent mb-4">Coming Soon</p>
+      <h1 class="text-display text-white section__heading">DealSnap</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl mx-auto section__description">Flexible discounts that actually work. Create mix-and-match bundles, quantity breaks, and automatic discount combinations — without fighting Shopify's native limitations.</p>
+      <Button variant="primary" size="lg" href="/contact/">Join the Waitlist</Button>
+    </div>
+  </Section>
+
+  <!-- The Problem -->
+  <Section background="cream">
+    <div class="animate-fade-in">
+      <h2 class="text-h2 section__heading">Shopify's Discount System Has Limits</h2>
+      <p class="text-body-lg text-neutral-700 max-w-2xl">Shopify's built-in discount system is fine for simple use cases — a percentage off, a fixed amount, buy X get Y. But the moment you need mix-and-match bundles, quantity breaks across collections, or stacking multiple automatic discounts, you hit walls. Merchants end up duct-taping workarounds together or paying for bloated apps that do ten things they don't need.</p>
+    </div>
+  </Section>
+
+  <!-- Features -->
+  <Section background="white">
+    <div class="text-center animate-fade-in">
+      <h2 class="text-h2 section__heading">What DealSnap Does</h2>
+      <p class="text-body-lg text-neutral-600 section__description">One app. Flexible discount rules. No workarounds.</p>
+    </div>
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {features.map((feature) => (
+        <div>
+          <h3 class="text-h3 section__heading">{feature.title}</h3>
+          <p class="text-body text-neutral-600">{feature.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- Who It's For -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Built For</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {audiences.map((audience) => (
+        <div class="text-center">
+          <h3 class="text-h3 section__heading">{audience.title}</h3>
+          <p class="text-body text-neutral-600">{audience.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- FAQ -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Frequently Asked Questions</h2>
+    <Accordion items={faqs} />
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Want to Try DealSnap?"
+    description="Join the waitlist and be first to know when it launches."
+    buttonText="Join the Waitlist"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/pages/apps/index.astro
+++ b/src/pages/apps/index.astro
@@ -1,0 +1,117 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Button from '../../components/Button.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "name": "Lading & Launch",
+      "url": "https://ladingandlaunch.com",
+      "makesOffer": [
+        { "@type": "Offer", "itemOffered": { "@type": "SoftwareApplication", "name": "DealSnap", "applicationCategory": "BusinessApplication" } },
+        { "@type": "Offer", "itemOffered": { "@type": "SoftwareApplication", "name": "Scratch & Win", "applicationCategory": "BusinessApplication" } }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://ladingandlaunch.com/apps/" }
+      ]
+    }
+  ]
+};
+
+const apps = [
+  {
+    title: 'DealSnap',
+    tagline: 'Flexible discounts that actually work.',
+    description: "Create mix-and-match bundles, quantity breaks, and automatic discount combinations — without the workarounds Shopify's native system forces you into.",
+    features: [
+      'Mix-and-match bundle discounts',
+      'Quantity break pricing',
+      'Automatic discount combinations',
+      'Works with existing Shopify discount codes',
+    ],
+    href: '/apps/dealsnap/',
+  },
+  {
+    title: 'Scratch & Win',
+    tagline: 'Email capture that people actually enjoy.',
+    description: 'Replace boring popups with gamified scratch cards. Visitors scratch to reveal a discount — you capture their email and create a moment they remember.',
+    features: [
+      'Gamified scratch card overlays',
+      'Email capture built in',
+      'Customizable discount reveals',
+      'Mobile-optimized experience',
+    ],
+    href: '/apps/scratch-and-win/',
+  },
+];
+---
+
+<BaseLayout
+  title="Shopify Apps — DealSnap & Scratch & Win | Lading & Launch"
+  description="Shopify apps built by the team that builds your store. DealSnap for flexible discounts and bundles. Scratch & Win for gamified email capture. Coming soon."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <div class="text-center animate-fade-in">
+      <p class="text-label text-accent mb-4">Our Apps</p>
+      <h1 class="text-display text-white section__heading">Shopify Apps Built by Store Builders</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl mx-auto">We don't just build stores — we build the tools merchants need. Our apps solve real problems that we see every day working with Shopify brands.</p>
+    </div>
+  </Section>
+
+  <!-- App Cards -->
+  <Section background="cream">
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {apps.map((app) => (
+        <Card href={app.href}>
+          <p class="text-label text-accent mb-3">Coming Soon</p>
+          <h2 class="card__title text-h2">{app.title}</h2>
+          <p class="text-body-lg text-neutral-700 section__heading">{app.tagline}</p>
+          <p class="card__description">{app.description}</p>
+          <ul class="text-body-sm text-neutral-600 space-y-1 mb-4">
+            {app.features.map((feature) => (
+              <li>&#10003; {feature}</li>
+            ))}
+          </ul>
+          <span class="text-body-sm text-primary-light font-semibold">Learn More &rarr;</span>
+        </Card>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- Why We Build Apps -->
+  <Section background="white">
+    <div class="text-center animate-fade-in">
+      <h2 class="text-h2 section__heading">Why an Agency Builds Apps</h2>
+      <p class="text-body-lg text-neutral-700 max-w-2xl mx-auto">Working with Shopify merchants every day, we see the same problems over and over. Instead of recommending third-party apps that half-solve the problem, we build our own. That deeper product engineering expertise shows in every store we build too.</p>
+    </div>
+  </Section>
+
+  <!-- Early Access -->
+  <Section background="cream">
+    <div class="text-center animate-fade-in">
+      <h2 class="text-h2 section__heading">Want Early Access?</h2>
+      <p class="text-body-lg text-neutral-700 max-w-2xl mx-auto section__description">Both apps are in development and launching soon. If you're a Shopify merchant who wants to try them first, reach out — we're looking for beta testers.</p>
+      <Button variant="primary" href="/contact/">Get in Touch</Button>
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Need a Store to Go With That App?"
+    description="We build Shopify stores too. Check out our services or book a call."
+    buttonText="View Services"
+    buttonHref="/services/"
+  />
+</BaseLayout>

--- a/src/pages/apps/scratch-and-win.astro
+++ b/src/pages/apps/scratch-and-win.astro
@@ -1,0 +1,152 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Button from '../../components/Button.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import Grid from '../../components/Grid.astro';
+import Accordion from '../../components/Accordion.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const faqs = [
+  {
+    question: 'When will Scratch & Win be available?',
+    answer: "Scratch & Win is in development and launching on the Shopify App Store soon. Join the waitlist to be notified.",
+  },
+  {
+    question: 'How much will it cost?',
+    answer: "Pricing will be announced at launch. We're planning simple, affordable tiers starting under $20/month with a free trial.",
+  },
+  {
+    question: 'Can I customize the look of the scratch card?',
+    answer: "Yes. You'll be able to customize colors, text, and the rewards to match your brand. No generic-looking widgets.",
+  },
+  {
+    question: 'Will it slow down my store?',
+    answer: "No. Scratch & Win loads asynchronously and has zero impact on your store's page speed or Lighthouse scores.",
+  },
+];
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "name": "Scratch & Win",
+      "description": "Gamified scratch cards that capture emails and drive urgency on Shopify stores.",
+      "applicationCategory": "BusinessApplication",
+      "operatingSystem": "Shopify",
+      "author": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Apps", "item": "https://ladingandlaunch.com/apps/" },
+        { "@type": "ListItem", "position": 3, "name": "Scratch & Win", "item": "https://ladingandlaunch.com/apps/scratch-and-win/" }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": faqs.map(faq => ({
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
+      }))
+    }
+  ]
+};
+
+const features = [
+  { title: 'Gamified Scratch Cards', description: "Visitors scratch to reveal a discount — it's physical, fun, and creates a dopamine hit that popups can't match. Higher engagement means more emails captured." },
+  { title: 'Built-In Email Capture', description: 'Every scratch requires an email address. No extra forms, no extra steps. The game IS the capture mechanism.' },
+  { title: 'Customizable Rewards', description: 'Set your own discount tiers and win probabilities. 10% for everyone? A rare 30% for lucky scratchers? You control the experience.' },
+  { title: 'Mobile-First Design', description: 'Scratch cards work beautifully on touch screens. Over 70% of your traffic is mobile — this is built for them.' },
+];
+
+const audiences = [
+  { title: 'DTC Brands', description: 'Brands that want to grow their email list with higher opt-in rates than traditional popups.' },
+  { title: 'Stores Running Promotions', description: 'Stores that run seasonal sales or flash promotions and want to create urgency and excitement.' },
+  { title: 'High-Traffic Stores', description: 'Stores with significant traffic that need to convert more visitors into subscribers before they leave.' },
+];
+---
+
+<BaseLayout
+  title="Scratch & Win — Gamified Email Capture for Shopify | Lading & Launch"
+  description="Replace boring popups with gamified scratch cards. Capture emails, drive urgency, and create moments customers remember. Scratch & Win by Lading & Launch — coming soon."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: 'Apps', href: '/apps/' },
+      { label: 'Scratch & Win' },
+    ]} />
+    <div class="text-center animate-fade-in">
+      <p class="text-label text-accent mb-4">Coming Soon</p>
+      <h1 class="text-display text-white section__heading">Scratch &amp; Win</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl mx-auto section__description">Email capture that people actually enjoy. Replace boring popups with gamified scratch cards that capture emails and create urgency — in one interaction.</p>
+      <Button variant="primary" size="lg" href="/contact/">Join the Waitlist</Button>
+    </div>
+  </Section>
+
+  <!-- The Problem -->
+  <Section background="cream">
+    <div class="animate-fade-in">
+      <h2 class="text-h2 section__heading">Popups Are Broken</h2>
+      <p class="text-body-lg text-neutral-700 max-w-2xl">Every Shopify store has a popup. Most visitors close it immediately. The "spin the wheel" widgets from 2019 aren't fooling anyone anymore. You're spending money driving traffic to your store, and your email capture tool is actively annoying the people you paid to bring there. You need something that makes visitors want to engage, not reach for the X button.</p>
+    </div>
+  </Section>
+
+  <!-- Features -->
+  <Section background="white">
+    <div class="text-center animate-fade-in">
+      <h2 class="text-h2 section__heading">What Scratch &amp; Win Does</h2>
+      <p class="text-body-lg text-neutral-600 section__description">A scratch card overlay that turns email capture into a game.</p>
+    </div>
+    <Grid cols={2} class="animate-fade-in-stagger">
+      {features.map((feature) => (
+        <div>
+          <h3 class="text-h3 section__heading">{feature.title}</h3>
+          <p class="text-body text-neutral-600">{feature.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- Who It's For -->
+  <Section background="cream">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Built For</h2>
+    <Grid cols={3} class="animate-fade-in-stagger">
+      {audiences.map((audience) => (
+        <div class="text-center">
+          <h3 class="text-h3 section__heading">{audience.title}</h3>
+          <p class="text-body text-neutral-600">{audience.description}</p>
+        </div>
+      ))}
+    </Grid>
+  </Section>
+
+  <!-- FAQ -->
+  <Section background="white">
+    <h2 class="text-h2 text-center section__heading animate-fade-in">Frequently Asked Questions</h2>
+    <Accordion items={faqs} />
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Want to Try Scratch & Win?"
+    description="Join the waitlist and be first to know when it launches."
+    buttonText="Join the Waitlist"
+    buttonHref="/contact/"
+  />
+</BaseLayout>


### PR DESCRIPTION
New pages:
- /apps/ — overview with linked cards, credibility section, early access CTA
- /apps/dealsnap/ — problem/solution, features, audience, FAQ with accordion
- /apps/scratch-and-win/ — problem/solution, features, audience, FAQ with accordion

Both apps marked Coming Soon throughout. JSON-LD includes SoftwareApplication, BreadcrumbList, and FAQPage schemas. Footer app links updated to individual detail pages.