### PR TITLE
Add blog listing, post template, first 2 articles, and SVG icon system

### DIFF
--- a/src/assets/icons/chevron-down.svg
+++ b/src/assets/icons/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>

--- a/src/assets/icons/close.svg
+++ b/src/assets/icons/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18L18 6M6 6l12 12"/></svg>

--- a/src/assets/icons/menu.svg
+++ b/src/assets/icons/menu.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>

--- a/src/components/Accordion.astro
+++ b/src/components/Accordion.astro
@@ -1,4 +1,6 @@
 ---
+import chevronIcon from '../assets/icons/chevron-down.svg?raw';
+
 interface Props {
   items: Array<{ question: string; answer: string }>;
 }
@@ -9,7 +11,10 @@ const { items } = Astro.props;
 <div class="accordion">
   {items.map((item) => (
     <details class="accordion__item">
-      <summary class="accordion__question">{item.question}</summary>
+      <summary class="accordion__question">
+        <span>{item.question}</span>
+        <span class="accordion__chevron" set:html={chevronIcon} />
+      </summary>
       <div class="accordion__answer">
         <p>{item.answer}</p>
       </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,7 @@
 ---
 import Button from './Button.astro';
+import menuIcon from '../assets/icons/menu.svg?raw';
+import closeIcon from '../assets/icons/close.svg?raw';
 
 const navLinks = [
   { label: 'Services', path: '/services/' },
@@ -45,9 +47,7 @@ const currentPath = Astro.url.pathname;
         aria-expanded="false"
         aria-label="Open menu"
       >
-        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
+        <span class="w-6 h-6" set:html={menuIcon} />
       </button>
     </div>
   </div>
@@ -56,9 +56,7 @@ const currentPath = Astro.url.pathname;
 <!-- Full-screen mobile menu overlay -->
 <div id="mobile-menu" class="mobile-menu" aria-label="Mobile navigation" role="dialog" aria-modal="true">
   <button id="mobile-menu-close" class="mobile-menu__close" aria-label="Close menu">
-    <svg class="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-    </svg>
+    <span class="w-7 h-7" set:html={closeIcon} />
   </button>
   <div class="mobile-menu__inner">
     <nav class="flex flex-col items-center gap-7 mb-10">

--- a/src/content/blog/coming-soon.md
+++ b/src/content/blog/coming-soon.md
@@ -1,9 +1,0 @@
----
-title: "Coming Soon"
-description: "The Captain's Log is launching soon."
-date: 2026-04-09
-tags: ["announcement"]
-draft: true
----
-
-Placeholder post. Replace with real content.

--- a/src/content/blog/how-much-does-a-custom-shopify-store-cost.md
+++ b/src/content/blog/how-much-does-a-custom-shopify-store-cost.md
@@ -1,0 +1,116 @@
+---
+title: "How Much Does a Custom Shopify Store Cost in 2026?"
+description: "A transparent breakdown of Shopify store build pricing in 2026 — from DIY themes to full custom builds. What to expect, what drives cost, and how to budget."
+date: 2026-04-15
+tags: ["shopify", "pricing", "store builds"]
+author: "Lading & Launch"
+draft: false
+---
+
+A custom Shopify store in 2026 costs between **$2,000 and $15,000+** depending on complexity. Most small-to-mid DTC brands land in the $3,000–$7,000 range for a professionally built store with custom design, mobile optimization, and SEO.
+
+That's the direct answer. The rest of this post breaks down exactly what drives those numbers so you can budget with confidence.
+
+## The Cost Spectrum
+
+Not every brand needs the same level of build. Here's how the pricing tiers break down in 2026:
+
+### DIY with a Premium Theme — $0–$500
+
+If you're bootstrapping, this is a real option. Shopify's theme store has solid premium themes in the $250–$400 range. You'll spend time instead of money — expect 20–40 hours to set up a theme yourself, add products, configure settings, and write your pages. The result won't be custom, but it can look professional and functional.
+
+**Best for:** Pre-revenue brands testing a product idea. Founders who are comfortable with tech and willing to invest the time.
+
+### Theme Customization / Starter Build — $2,000–$3,500
+
+This is where most agencies start. You get a premium theme customized to your brand — colors, typography, layout adjustments, and product page setup. It's not a ground-up design, but it goes well beyond what you'd get doing it yourself.
+
+At [Lading & Launch](/services/store-builds/), our Starter Store package falls in this range and includes theme customization, up to 15 products set up, essential pages, mobile-responsive design, basic on-page SEO, and a 1-2 week delivery timeline.
+
+**Best for:** New brands launching their first store who want something polished without a five-figure budget.
+
+### Custom Theme Build — $4,000–$7,000
+
+This is the sweet spot for growing DTC brands. You get a custom-designed theme built specifically for your brand, with advanced functionality like bundles, subscriptions, or upsells baked in. The design is yours — not a template with your colors swapped in.
+
+This range also typically includes full SEO implementation, third-party app integrations, and more extensive product setup.
+
+**Best for:** Brands with traction that need a store designed to convert, not just look nice.
+
+### Full Custom Build / Shopify Plus — $8,000–$15,000+
+
+Enterprise-level builds for brands with complex requirements. This includes fully custom functionality, ERP and 3PL integrations, Shopify Plus configuration, and custom app development. Timelines are longer (4-8 weeks) and the scope is significantly larger.
+
+**Best for:** Established brands doing significant revenue that need a store matching their operational complexity.
+
+## What Drives the Price Up
+
+Within any tier, several factors push cost toward the higher end:
+
+**Number of products and variants.** Setting up 10 products is very different from setting up 500. Each product needs titles, descriptions, images, variant configurations, and collection assignments. More products means more setup time.
+
+**Custom functionality.** Subscriptions, loyalty programs, bundle builders, custom discount logic — any feature that goes beyond Shopify's defaults requires development time. The more custom the functionality, the higher the cost.
+
+**Third-party integrations.** Connecting your store to an ERP, 3PL, email marketing platform, reviews system, or accounting software adds complexity. Simple integrations (Klaviyo, Judge.me) are routine. Complex ones (NetSuite, custom APIs) add significant cost.
+
+**Design complexity.** A clean, conversion-focused design is standard. Custom illustrations, scroll animations, interactive product configurators, or lookbook-style layouts require additional design and development time.
+
+**Platform migration.** If you're moving from WooCommerce, Wix, or another platform, add $1,500–$5,000 for data migration, URL redirect mapping, and QA testing. See our [migration services](/services/migration/) for details.
+
+## What's Usually Included
+
+At the $3,000–$7,000 range, here's what a typical Shopify agency build includes:
+
+- **Custom theme design and development** — either a heavily customized premium theme or a custom build from scratch
+- **Mobile-responsive design** — the store looks and works correctly on all devices
+- **Product setup** — your products loaded with titles, descriptions, images, and variants
+- **Essential pages** — Home, About, Contact, FAQ, shipping and return policies
+- **On-page SEO** — meta tags, semantic HTML, image optimization, schema markup, XML sitemap
+- **Speed optimization** — clean code, optimized images, fast load times
+- **Launch support** — Shopify training, launch QA, and post-launch check-in
+
+**What's usually NOT included** (and that's normal):
+
+- Product photography
+- Copywriting for product descriptions and pages
+- Ongoing content creation
+- Paid advertising setup or management
+- Custom app development (beyond standard integrations)
+- Ongoing monthly management (though we offer [management plans](/services/management/) starting at $300/mo)
+
+## How to Budget for Your Store
+
+The store build is the biggest upfront cost, but it's not the only one. A lot of merchants budget for the build and then get surprised by the ongoing costs of running a Shopify store. Here's a realistic year-one budget for a typical DTC brand so there are no surprises:
+
+**Upfront costs:**
+- Shopify store build: $3,000–$7,000
+- Domain name: $15–$50/year
+- Premium apps (reviews, email, etc.): $50–$200/month
+
+**Ongoing monthly costs:**
+- Shopify plan: $39/month (Basic) to $399/month (Advanced)
+- App subscriptions: $100–$300/month
+- Management/support: $300–$500/month (optional but recommended)
+
+**Total year-one cost for a typical DTC brand: $5,000–$12,000 all-in** — including the build, platform fees, apps, and optional management. That's the real number, not just the build cost in isolation.
+
+A common mistake is spending your entire budget on the build and having nothing left for marketing, apps, or ongoing support. A slightly more modest store with budget reserved for post-launch optimization and advertising will almost always outperform a premium store with no money left to drive traffic to it.
+
+## Questions to Ask Any Shopify Agency
+
+Before you hire anyone — whether it's us or someone else — ask these questions. The answers will tell you a lot about how the agency operates:
+
+1. **What's included in the price?** Get a detailed scope document, not a vague estimate.
+2. **What's NOT included?** This is where surprises hide. Make sure you know what's extra.
+3. **How many revision rounds?** Two to three rounds is standard. Unlimited revisions usually means the scope isn't well-defined.
+4. **What's the timeline?** Get specific dates, not "a few weeks."
+5. **Do you offer ongoing support after launch?** Stores need maintenance. Know your options before you need them.
+6. **Can I see your previous Shopify work?** Look at real stores, not just screenshots.
+
+## The Bottom Line
+
+A good Shopify store is an investment that pays for itself through better conversion rates, faster load times, and a professional brand presence that makes customers confident enough to buy. The key is matching the build level to your actual needs — don't over-build for a brand that's still finding product-market fit, and don't under-build for a brand that's ready to scale.
+
+The worst outcome isn't spending too much or too little — it's spending the right amount with the wrong partner and ending up with a store that looks like a template and performs like one too. Take the time to vet your agency, understand the scope, and make sure the people building your store actually specialize in the platform.
+
+At Lading & Launch, our [store builds start at $2,000](/services/store-builds/) and our pricing is published so you know what to expect before the first conversation. If you're planning a Shopify store and want to talk through your options, [book a free discovery call](/contact/).

--- a/src/content/blog/shopify-store-mistakes-that-kill-conversion-rate.md
+++ b/src/content/blog/shopify-store-mistakes-that-kill-conversion-rate.md
@@ -1,0 +1,90 @@
+---
+title: "5 Shopify Store Mistakes That Kill Your Conversion Rate"
+description: "Common Shopify store mistakes that drive customers away — and how to fix them. Speed, mobile, product pages, checkout, and trust signals."
+date: 2026-04-12
+tags: ["shopify", "conversion", "optimization"]
+author: "Lading & Launch"
+draft: false
+---
+
+The average Shopify store converts at 1.5–2%. Most stores we look at are well below that — and the problems are almost always the same five things. None of them are hard to fix, but most merchants don't realize they're losing sales until someone points it out.
+
+Here are the five most common Shopify store mistakes that kill conversion rates, and exactly how to fix each one.
+
+## 1. Slow Page Speed
+
+Every one-second delay in page load time costs you roughly 7% in conversions. That's not a guess — it's been measured across millions of e-commerce transactions. If your store takes 4 seconds to load instead of 2, you're leaving real money on the table.
+
+**Common causes of slow Shopify stores:**
+
+- **Too many apps installed.** Every app adds JavaScript to your store. Install 15 apps and your store is loading 15 separate scripts. Audit your apps quarterly and remove anything you're not actively using.
+- **Unoptimized images.** A single 5MB product image will tank your load time. Compress every image before uploading. Use WebP format when possible. Target under 200KB per image.
+- **Heavy theme code.** Some themes are bloated with features you'll never use. If your theme's JavaScript bundle is over 300KB, it's too heavy.
+- **No lazy loading.** Images below the fold should load only when the visitor scrolls to them. If all your images load at once, your initial page load suffers.
+
+**Quick fixes:** Start with an app audit. Remove anything unused. Run your store through Google PageSpeed Insights and address the top 3 recommendations. Compress your images. If your theme is the bottleneck, it might be time for a [new build](/services/store-builds/) with a performance-first approach.
+
+For a deeper dive, a [store audit](/services/optimization/) will identify every speed issue and prioritize the fixes by impact.
+
+## 2. Poor Mobile Experience
+
+Over 70% of Shopify traffic comes from mobile devices. If your store isn't optimized for mobile, the majority of your visitors are having a bad experience — and most of them won't tell you. They'll just leave.
+
+**Common mobile problems:**
+
+- **Tiny tap targets.** Buttons and links that are easy to click with a mouse but impossible to tap with a thumb. Every interactive element should be at least 44px tall.
+- **Horizontal scrolling.** Any content wider than the screen forces horizontal scrolling on mobile. This is almost always caused by images or tables that aren't responsive.
+- **Slow mobile load.** Mobile connections are slower than desktop. If your store is borderline slow on desktop, it's painfully slow on mobile.
+- **Checkout friction.** A checkout that works fine on a 27-inch monitor can be frustrating on a phone screen. Small form fields, unclear error messages, and too many steps kill mobile conversions.
+
+**The fix:** Test your entire purchase flow on a real phone. Not Chrome DevTools — an actual phone. Start from the homepage, browse products, add to cart, and go through checkout. Do it on both iPhone and Android. Every point of friction you experience is a point where customers drop off.
+
+## 3. Weak Product Pages
+
+The product page is where the buying decision happens. Everything else on your store — the homepage, the navigation, the collection pages — exists to get visitors to a product page. If that page doesn't close the sale, nothing else matters.
+
+**Common product page problems:**
+
+- **One product photo.** You need 4-6 photos minimum. Show the product from multiple angles, in context, with size reference. Customers can't touch it — your photos are the next best thing.
+- **Vague descriptions.** "This is a great product made with quality materials" tells the customer nothing. Write descriptions that answer specific objections: What's it made of? How big is it? How does it fit? How do I care for it? What makes it better than the alternative?
+- **No trust signals.** No reviews, no ratings, no guarantee information. First-time visitors need social proof before they'll hand over payment info.
+- **Buried CTA.** The "Add to Cart" button should be visible without scrolling on desktop and easily reachable on mobile. If customers have to hunt for it, some of them won't bother.
+
+**The fix:** Look at the top-performing stores in your niche. Notice how many images they use, how their descriptions are structured, where reviews appear, and where the Add to Cart button sits. Then compare to your store. The gaps will be obvious.
+
+If your [product pages need a redesign](/services/store-builds/), that's one of the highest-ROI improvements you can make. A well-designed product page can double your conversion rate on its own.
+
+## 4. Complicated Checkout
+
+Shopify's native checkout is actually one of the best in e-commerce. But stores still manage to mess it up.
+
+**Common checkout mistakes:**
+
+- **Requiring account creation.** Forcing visitors to create an account before purchasing adds friction. Enable guest checkout. Always. You can invite them to create an account after they've paid.
+- **Too many upsells.** One post-add-to-cart upsell is fine. Three sequential upsell popups before reaching checkout makes your store feel like a late-night infomercial.
+- **Limited payment options.** If you're not offering Shop Pay, Apple Pay, and Google Pay, you're making customers type in card numbers on their phone. One-tap payment methods significantly reduce checkout abandonment.
+- **Surprise costs.** Shipping charges, taxes, or fees that appear only at checkout are the #1 reason for cart abandonment across all e-commerce. Show shipping costs on the product page or in the cart — before checkout.
+
+**The fix:** Enable every express payment method Shopify offers. Enable guest checkout. Limit upsells to one. Show shipping costs early. Then watch your checkout completion rate improve.
+
+## 5. No Trust Signals
+
+First-time visitors to your store don't know you. They've never heard of your brand. They're being asked to enter their credit card number on a website they found five minutes ago. Trust signals are what bridge that gap.
+
+**Common trust signal gaps:**
+
+- **No reviews.** Even 5-10 reviews dramatically increase purchase confidence. If you're new, send your product to friends or early customers and ask them to review it.
+- **No return policy visible.** Customers assume the worst when they can't find a return policy. Display it prominently — on product pages, not just buried in the footer.
+- **No security indicators.** SSL badges, secure checkout messaging, and payment provider logos (Visa, Mastercard, PayPal) reassure customers that their payment info is safe.
+- **No shipping information.** "How long will it take?" and "How much will shipping cost?" are questions every customer has. Answer them on the product page, not after they've entered their address at checkout.
+- **No About page.** A real About page with your story, your face, and your location makes you a real person, not an anonymous dropshipper. This matters more than most merchants realize.
+
+**The fix:** Add reviews (even a few), display your return policy on product pages, add trust badges near the Add to Cart button, show shipping timeframes and costs, and build out your [About page](/about/) with real information about your brand.
+
+## What to Do Next
+
+If your store has two or more of these problems, you're almost certainly leaving significant revenue on the table. The good news is that every one of these issues is fixable, and the fixes usually pay for themselves quickly through higher conversion rates.
+
+The fastest way to get a prioritized fix list is a [store audit](/services/optimization/). We review your entire store — speed, mobile, product pages, checkout, trust signals — and deliver an actionable report with specific recommendations ranked by impact. Store audits start at $500.
+
+If you want to talk through what your store needs, [book a free discovery call](/contact/) and we'll give you an honest assessment — even if the answer is "you're fine, don't spend money on this."

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,103 @@
+---
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Button from '../../components/Button.astro';
+import Breadcrumb from '../../components/Breadcrumb.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const canonicalUrl = `https://ladingandlaunch.com/blog/${post.id}/`;
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BlogPosting",
+      "headline": post.data.title,
+      "description": post.data.description,
+      "datePublished": post.data.date.toISOString(),
+      "author": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Lading & Launch",
+        "url": "https://ladingandlaunch.com"
+      },
+      "mainEntityOfPage": canonicalUrl
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Captain's Log", "item": "https://ladingandlaunch.com/blog/" },
+        { "@type": "ListItem", "position": 3, "name": post.data.title }
+      ]
+    }
+  ]
+};
+---
+
+<BaseLayout
+  title={`${post.data.title} | Lading & Launch`}
+  description={post.data.description}
+  ogImage={post.data.image || '/images/og-default.jpg'}
+  ogType="article"
+  canonicalUrl={canonicalUrl}
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <Breadcrumb items={[
+      { label: 'Home', href: '/' },
+      { label: "Captain's Log", href: '/blog/' },
+      { label: post.data.title },
+    ]} />
+    <div class="text-center animate-fade-in">
+      <p class="text-body-sm text-neutral-300 mb-4">{formatDate(post.data.date)}</p>
+      <h1 class="text-display text-white section__heading">{post.data.title}</h1>
+      <p class="text-body-lg text-neutral-300 max-w-2xl mx-auto section__description">{post.data.description}</p>
+      {post.data.tags && (
+        <div class="flex flex-wrap gap-2 justify-center">
+          {post.data.tags.map((tag: string) => (
+            <span class="text-label text-accent text-xs">{tag}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  </Section>
+
+  <!-- Article Content -->
+  <Section background="white">
+    <article class="prose max-w-3xl mx-auto">
+      <Content />
+    </article>
+  </Section>
+
+  <!-- Post Footer -->
+  <Section background="cream" compact>
+    <div class="text-center">
+      <Button variant="secondary" href="/blog/">← Back to Captain's Log</Button>
+    </div>
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner />
+</BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,82 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Section from '../../components/Section.astro';
+import Card from '../../components/Card.astro';
+import Grid from '../../components/Grid.astro';
+import CTABanner from '../../components/CTABanner.astro';
+
+const posts = (await getCollection('blog', ({ data }) => data.draft !== true))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Blog",
+      "name": "Captain's Log",
+      "description": "Shopify guides, tips, and insights for e-commerce brands.",
+      "url": "https://ladingandlaunch.com/blog/"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Captain's Log", "item": "https://ladingandlaunch.com/blog/" }
+      ]
+    }
+  ]
+};
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+---
+
+<BaseLayout
+  title="Captain's Log — Shopify Tips, Guides & Insights | Lading & Launch"
+  description="Shopify guides, tips, and insights for e-commerce brands. Store builds, optimization, migration, and conversion — from the team at Lading & Launch."
+  schema={schema}
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <div class="text-center animate-fade-in">
+      <p class="text-label text-accent mb-4">Blog</p>
+      <h1 class="text-display text-white section__heading">Captain's Log</h1>
+      <p class="text-body-lg text-neutral-300">Shopify guides, tips, and insights for growing e-commerce brands.</p>
+    </div>
+  </Section>
+
+  <!-- Post Grid -->
+  <Section background="cream">
+    {posts.length > 0 ? (
+      <Grid cols={2} class="animate-fade-in-stagger">
+        {posts.map((post) => (
+          <Card href={`/blog/${post.id}/`}>
+            <p class="text-body-sm text-neutral-500 mb-2">{formatDate(post.data.date)}</p>
+            <h2 class="card__title">{post.data.title}</h2>
+            <p class="card__description">{post.data.description}</p>
+            {post.data.tags && (
+              <div class="flex flex-wrap gap-2 mb-3">
+                {post.data.tags.map((tag: string) => (
+                  <span class="text-label text-accent text-xs">{tag}</span>
+                ))}
+              </div>
+            )}
+            <span class="text-body-sm text-primary-light font-semibold">Read Post &rarr;</span>
+          </Card>
+        ))}
+      </Grid>
+    ) : (
+      <p class="text-body-lg text-neutral-500 text-center">Posts are on the way. Check back soon.</p>
+    )}
+  </Section>
+
+  <!-- CTA -->
+  <CTABanner
+    heading="Need Help With Your Shopify Store?"
+    description="We build, optimize, and manage Shopify stores for growing e-commerce brands."
+    buttonText="Book a Discovery Call"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -145,9 +145,61 @@
   @apply font-sans text-sm font-medium uppercase tracking-wide;
 }
 
-/* Prose spacing */
+/* Prose — blog article typography */
+.prose h2 {
+  @apply font-serif text-xl md:text-3xl font-semibold leading-snug mt-12 mb-4;
+}
+
+.prose h3 {
+  @apply font-sans text-lg md:text-xl font-semibold leading-snug mt-8 mb-3;
+}
+
+.prose p {
+  @apply font-sans text-base leading-relaxed text-neutral-700;
+}
+
 .prose p + p {
   @apply mt-6;
+}
+
+.prose ul {
+  @apply text-base leading-relaxed text-neutral-700 pl-6 mb-6 list-disc;
+}
+
+.prose ol {
+  @apply text-base leading-relaxed text-neutral-700 pl-6 mb-6 list-decimal;
+}
+
+.prose li {
+  @apply mb-2;
+}
+
+.prose strong {
+  @apply font-semibold text-neutral-800;
+}
+
+.prose a {
+  @apply text-primary-light underline hover:text-primary;
+}
+
+.prose blockquote {
+  @apply border-l-4 border-accent pl-6 italic text-neutral-600 my-6;
+}
+
+.prose code {
+  @apply bg-neutral-100 px-1.5 py-0.5 rounded text-sm font-mono;
+}
+
+.prose pre {
+  @apply bg-neutral-900 text-neutral-100 p-6 rounded-xl overflow-x-auto my-6;
+}
+
+.prose img {
+  @apply rounded-xl my-8;
+}
+
+.prose hr {
+  @apply border-neutral-200 my-8;
 }
 
 /* ============================================================
@@ -162,9 +214,8 @@
   @apply border-b border-neutral-200;
 }
 
-.accordion__item[open] .accordion__question::after {
-  transform: rotate(225deg);
-  @apply mt-1;
+.accordion__item[open] .accordion__chevron {
+  @apply rotate-180;
 }
 
 .accordion__question {
@@ -175,9 +226,8 @@
   @apply hidden;
 }
 
-.accordion__question::after {
-  content: '';
-  @apply w-2.5 h-2.5 border-r-2 border-b-2 border-current rotate-45 transition-transform duration-200 ease-out shrink-0 -mt-1;
+.accordion__chevron {
+  @apply w-5.5 h-5.5 shrink-0 transition-transform duration-200 ease-out text-neutral-700 mr-2;
 }
 
 .accordion__answer {


### PR DESCRIPTION
Blog:
- /blog/ listing page with post grid, empty state, CTA
- /blog/[slug]/ dynamic post template with prose typography
- "How Much Does a Custom Shopify Store Cost in 2026?" (~1,200 words)
- "5 Shopify Store Mistakes That Kill Your Conversion Rate" (~1,340 words)
- Prose typography BEM classes in global.css
- BlogPosting + BreadcrumbList JSON-LD on posts
- Delete coming-soon.md placeholder

Icons:
- Create src/assets/icons/ with menu.svg, close.svg, chevron-down.svg
- Header.astro imports SVGs via ?raw instead of inline markup
- Accordion.astro imports chevron-down.svg, removes CSS data URI
- Zero inline SVGs or data URIs remaining in components or CSS