### PR TITLE
Add 404, privacy policy, terms of service, and sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,19 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://ladingandlaunch.com',
+  integrations: [
+    sitemap({
+      filter: (page) =>
+        !['/404/', '/design-system/', '/privacy/', '/terms/'].some((path) =>
+          page.endsWith(path)
+        ),
+    }),
+  ],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lading-launch-website",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.5",
         "tailwindcss": "^4.2.2"
@@ -70,6 +71,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1964,6 +1976,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2000,6 +2030,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4779,6 +4815,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -4809,6 +4864,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4971,6 +5032,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.5",
     "tailwindcss": "^4.2.2"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,3 @@
-User-agent: Googlebot
-Allow: /
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /
-
 User-agent: *
 Allow: /
+Sitemap: https://ladingandlaunch.com/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ interface Props {
   canonicalUrl?: string;
   schema?: object;
   noindex?: boolean;
+  robots?: string;
 }
 
 const {
@@ -21,6 +22,7 @@ const {
   canonicalUrl = Astro.url.href,
   schema,
   noindex = false,
+  robots,
 } = Astro.props;
 
 const ogImageUrl = new URL(ogImage, Astro.site).href;
@@ -33,7 +35,7 @@ const ogImageUrl = new URL(ogImage, Astro.site).href;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    {noindex && <meta name="robots" content="noindex, nofollow" />}
+    {robots ? <meta name="robots" content={robots} /> : noindex && <meta name="robots" content="noindex, nofollow" />}
     <link rel="canonical" href={canonicalUrl} />
 
     <!-- Open Graph -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,23 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Section from '../components/Section.astro';
+import Button from '../components/Button.astro';
+---
+
+<BaseLayout
+  title="Page Not Found | Lading & Launch"
+  description="The page you're looking for doesn't exist. Head back to the homepage or browse our Shopify services."
+  noindex={true}
+>
+  <Section background="primary" class="min-h-[60vh] flex items-center">
+    <div class="text-center animate-fade-in">
+      <p class="font-serif text-8xl md:text-9xl font-bold text-accent">404</p>
+      <h1 class="text-h1 text-white mt-4">Page Not Found</h1>
+      <p class="text-body-lg text-neutral-300 mt-4">The page you're looking for doesn't exist or has been moved.</p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center mt-8">
+        <Button variant="white" href="/">Back to Home</Button>
+        <Button variant="secondary-on-dark" href="/services/">Browse Services</Button>
+      </div>
+    </div>
+  </Section>
+</BaseLayout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,88 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Section from '../components/Section.astro';
+
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Privacy Policy", "item": "https://ladingandlaunch.com/privacy/" }
+  ]
+};
+---
+
+<BaseLayout
+  title="Privacy Policy | Lading & Launch"
+  description="Privacy policy for Lading & Launch — how we collect, use, and protect your information."
+  schema={schema}
+  robots="noindex, follow"
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <div class="animate-fade-in">
+      <h1 class="text-display text-white section__heading">Privacy Policy</h1>
+      <p class="text-body-sm text-neutral-300">Last updated: April 2026</p>
+    </div>
+  </Section>
+
+  <!-- Content -->
+  <Section background="white">
+    <article class="prose max-w-3xl mx-auto">
+      <p>This privacy policy describes how Lading & Launch LLC ("we," "us," or "our") collects, uses, and protects your information when you visit ladingandlaunch.com. This is not a legal document — it's written in plain language so you can actually understand it.</p>
+
+      <h2>Information We Collect</h2>
+
+      <h3>Information You Provide</h3>
+      <p>When you fill out our contact form, you provide your name, email address, and optionally your store URL and project details. When you book a call through Calendly, you provide your name, email, and scheduling preferences. We only collect what you give us directly.</p>
+
+      <h3>Information Collected Automatically</h3>
+      <p>We use Google Analytics 4 (GA4) to understand how people use our website. This collects anonymous data like pages visited, time on site, device type, browser, and referral source. This helps us improve the site — we don't use it to identify individuals.</p>
+      <p>We do not sell products directly through this website, so no payment card information is collected on ladingandlaunch.com. Payments for services are handled through Stripe invoicing, which has its own privacy protections.</p>
+
+      <h2>How We Use Your Information</h2>
+      <ul>
+        <li>To respond to your inquiries and contact form submissions</li>
+        <li>To provide the services you've requested</li>
+        <li>To improve our website and understand how visitors use it</li>
+        <li>To send relevant updates about our services or apps — only if you've opted in</li>
+      </ul>
+      <p>We don't sell your information. We don't share it with anyone except the third-party services listed below, and only as necessary to operate our business.</p>
+
+      <h2>Third-Party Services</h2>
+      <p>We use the following third-party services that may process your data:</p>
+      <ul>
+        <li><strong>Google Analytics 4</strong> — Website analytics. Collects anonymous usage data via cookies. <a href="https://policies.google.com/privacy">Google Privacy Policy</a></li>
+        <li><strong>Formspree</strong> — Contact form processing. Receives the data you submit through our contact form. <a href="https://formspree.io/legal/privacy-policy">Formspree Privacy Policy</a></li>
+        <li><strong>Calendly</strong> — Appointment scheduling. Receives your name, email, and scheduling data when you book a call. <a href="https://calendly.com/privacy">Calendly Privacy Policy</a></li>
+        <li><strong>Stripe</strong> — Payment processing for services. Handles invoicing and payment collection. <a href="https://stripe.com/privacy">Stripe Privacy Policy</a></li>
+      </ul>
+
+      <h2>Cookies</h2>
+      <p>Google Analytics 4 uses cookies to collect anonymous analytics data. We do not use advertising cookies, retargeting cookies, or any cookies for marketing purposes.</p>
+      <p>You can disable cookies in your browser settings. Disabling cookies won't affect your ability to use this website — you just won't be included in our analytics data.</p>
+
+      <h2>Data Retention</h2>
+      <p>Contact form submissions are retained for the duration of our business relationship and a reasonable period afterward. Analytics data is retained according to Google Analytics default settings (14 months). Calendly scheduling data is retained per Calendly's policies.</p>
+
+      <h2>Your Rights</h2>
+      <p>You have the right to:</p>
+      <ul>
+        <li>Request access to the personal data we hold about you</li>
+        <li>Request correction of inaccurate data</li>
+        <li>Request deletion of your data</li>
+        <li>Withdraw consent for any processing based on consent</li>
+      </ul>
+      <p>To exercise any of these rights, email <a href="mailto:hello@ladingandlaunch.com">hello@ladingandlaunch.com</a>. We'll respond within 30 days.</p>
+
+      <h2>Children's Privacy</h2>
+      <p>This website is not directed at children under 13. We do not knowingly collect personal information from children. If you believe we've collected data from a child, contact us and we'll delete it immediately.</p>
+
+      <h2>Changes to This Policy</h2>
+      <p>We may update this privacy policy from time to time. Changes will be posted on this page with an updated date at the top. We won't make material changes without making them clear.</p>
+
+      <h2>Contact</h2>
+      <p>Questions about this privacy policy? Email <a href="mailto:hello@ladingandlaunch.com">hello@ladingandlaunch.com</a>.</p>
+    </article>
+  </Section>
+</BaseLayout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,73 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Section from '../components/Section.astro';
+
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ladingandlaunch.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Terms of Service", "item": "https://ladingandlaunch.com/terms/" }
+  ]
+};
+---
+
+<BaseLayout
+  title="Terms of Service | Lading & Launch"
+  description="Terms of service for using the Lading & Launch website and engaging our Shopify agency services."
+  schema={schema}
+  robots="noindex, follow"
+>
+  <!-- Hero -->
+  <Section background="primary">
+    <div class="animate-fade-in">
+      <h1 class="text-display text-white section__heading">Terms of Service</h1>
+      <p class="text-body-sm text-neutral-300">Last updated: April 2026</p>
+    </div>
+  </Section>
+
+  <!-- Content -->
+  <Section background="white">
+    <article class="prose max-w-3xl mx-auto">
+      <p>These terms govern your use of ladingandlaunch.com, operated by Lading & Launch LLC. By using this website, you agree to these terms. If you don't agree, please don't use the site. This is written in plain language — not legalese.</p>
+
+      <h2>Services</h2>
+      <p>Lading & Launch provides Shopify store development, optimization, platform migration, ongoing management, and app development services. The content on this website describes our services in general terms.</p>
+      <p>Specific deliverables, timelines, pricing, and responsibilities for individual projects are defined in separate service agreements signed by both parties. Nothing on this website constitutes a binding offer or guarantee of specific results.</p>
+
+      <h2>Use of This Website</h2>
+      <p>You may use this website to learn about our services, read our blog, and contact us. You agree not to:</p>
+      <ul>
+        <li>Use the site for any unlawful purpose</li>
+        <li>Attempt to gain unauthorized access to any part of the site</li>
+        <li>Interfere with the site's operation or other users' access</li>
+        <li>Submit false information through the contact form</li>
+        <li>Scrape, crawl, or harvest content from the site without permission</li>
+      </ul>
+
+      <h2>Intellectual Property</h2>
+      <p>All content on this website — including text, design, code, blog posts, and graphics — is owned by Lading & Launch LLC unless otherwise noted. You may not reproduce, distribute, or create derivative works from our content without written permission.</p>
+      <p>Ownership of work produced for clients is governed by individual service agreements, not these website terms.</p>
+
+      <h2>Contact Form and Communications</h2>
+      <p>Information you submit through our contact form is used to respond to your inquiry and, if relevant, to scope potential work. Submitting a contact form does not create a client relationship, a contract, or an obligation for us to provide services.</p>
+      <p>We'll respond to inquiries as quickly as we can, typically within 24 hours on business days.</p>
+
+      <h2>Limitation of Liability</h2>
+      <p>This website and its content are provided "as is" for informational purposes. Our blog posts, guides, and recommendations are general advice based on our experience — they're not specific recommendations for your business or store.</p>
+      <p>Lading & Launch LLC is not liable for any decisions you make based on content found on this website. For advice specific to your situation, <a href="/contact/">get in touch</a> and we'll give you a proper assessment.</p>
+
+      <h2>Third-Party Links</h2>
+      <p>This website may contain links to third-party websites and services. We don't control those sites and aren't responsible for their content, privacy practices, or availability. A link doesn't mean we endorse the linked site.</p>
+
+      <h2>Changes to These Terms</h2>
+      <p>We may update these terms at any time. Changes take effect when posted on this page with an updated date. Your continued use of the site after changes are posted constitutes your acceptance of the updated terms.</p>
+
+      <h2>Governing Law</h2>
+      <p>These terms are governed by and construed in accordance with the laws of the State of Florida, United States. Any disputes arising from these terms or your use of the website will be resolved in the courts of Florida.</p>
+
+      <h2>Contact</h2>
+      <p>Questions about these terms? Email <a href="mailto:hello@ladingandlaunch.com">hello@ladingandlaunch.com</a>.</p>
+    </article>
+  </Section>
+</BaseLayout>


### PR DESCRIPTION
Pages:
- 404: gold 404, centered layout, two CTAs, noindex/nofollow
- Privacy policy at /privacy/: plain-language, covers GA4, Formspree, Calendly, Stripe. noindex/follow.
- Terms of service at /terms/: plain-language, Florida governing law, Lading & Launch LLC. noindex/follow.

Infrastructure:
- Install @astrojs/sitemap, configured to exclude /404, /design-system/, /privacy/, /terms/
- Update robots.txt with sitemap reference
- Add robots prop to BaseLayout for custom meta robots values