### PR TITLE
Non-blocking Google Fonts and explicit logo dimensions for CLS

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,7 +24,7 @@ const apps = [
     <div class="grid grid--4col">
       <!-- Brand -->
       <div>
-        <img src="/images/lading-launch-logo.svg" alt="Lading & Launch" class="h-9 mb-2" />
+        <img src="/images/lading-launch-logo.svg" alt="Lading & Launch" width="79" height="36" class="h-9 mb-2" />
         <p class="text-neutral-300 text-sm mb-4">Shopify stores built to sell.</p>
         <a href="mailto:hello@ladingandlaunch.com" class="footer__link">
           hello@ladingandlaunch.com

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,7 +19,7 @@ const currentPath = Astro.url.pathname;
     <div class="flex items-center justify-between h-16">
       <!-- Logo -->
       <a href="/" aria-label="Lading & Launch — Home">
-        <img src="/images/lading-launch-logo.svg" alt="Lading & Launch" class="h-9" />
+        <img src="/images/lading-launch-logo.svg" alt="Lading & Launch" width="79" height="36" class="h-9" />
       </a>
 
       <!-- Desktop Nav -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -58,13 +58,16 @@ const ogImageUrl = new URL(ogImage, Astro.site).href;
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
 
-    <!-- Google Fonts -->
+    <!-- Google Fonts (non-blocking) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap"
-      rel="stylesheet"
+      onload="this.onload=null;this.rel='stylesheet'"
     />
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" /></noscript>
 
     <!-- JSON-LD Schema -->
     {schema && (


### PR DESCRIPTION
- Switch Google Fonts from render-blocking <link rel="stylesheet"> to async preload with onload swap and noscript fallback
- Add width="79" height="36" to logo <img> in Header and Footer to eliminate cumulative layout shift during load